### PR TITLE
Update default url

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -128,10 +128,13 @@ export class Client {
   }
 
   public static getDefaultClientConfig(): { apiUrl: string; apiKey?: string } {
+    const apiKey = getEnvironmentVariable("LANGCHAIN_API_KEY");
+    const apiUrl =
+      getEnvironmentVariable("LANGCHAIN_ENDPOINT") ??
+      (apiKey ? "https://api.smith.langchain.com" : "http://localhost:1984");
     return {
-      apiUrl:
-        getEnvironmentVariable("LANGCHAIN_ENDPOINT") ?? "http://localhost:1984",
-      apiKey: getEnvironmentVariable("LANGCHAIN_API_KEY"),
+      apiUrl: apiUrl,
+      apiKey: apiKey,
     };
   }
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -148,13 +148,18 @@ class Client:
             LangSmithUserError: If the API key is not provided when using the
              hosted service.
         """
+        self.api_key = (
+            api_key if api_key is not None else os.getenv("LANGCHAIN_API_KEY")
+        )
         self.api_url = (
             api_url
             if api_url is not None
-            else os.getenv("LANGCHAIN_ENDPOINT", "http://localhost:1984")
-        )
-        self.api_key = (
-            api_key if api_key is not None else os.getenv("LANGCHAIN_API_KEY")
+            else os.getenv(
+                "LANGCHAIN_ENDPOINT",
+                "https://api.smith.langchain.com"
+                if self.api_key
+                else "http://localhost:1984",
+            )
         )
         _validate_api_key_if_hosted(self.api_url, self.api_key)
         self.retry_config = retry_config or _default_retry_config()


### PR DESCRIPTION
Currently presumes localhost if not specified.
Suggested change would be to assume prod `https://api.smith.langchain.com` if an api key is specified, otherwise fall back to localhost.

Would eliminate 1 strictly required env var 